### PR TITLE
avoid stripping exec bits off .pl files

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1398,7 +1398,7 @@ $description
 END
 
     if ($execs) {
-        print $spec "find . -type f -print0 | xargs -0 chmod 644\n";
+        print $spec "find . -type f ! -name \\*.pl -print0 | xargs -0 chmod 644\n";
     }
 
     if ($config->{patches}) {


### PR DESCRIPTION
this broke perl-Cv build
where there is a .jpg and .sh file with exec bits
but dumpconst.pl and others need to keep their exec bits.