### PR TITLE
Prevent invalid "perl-.spec" and "perl-.changes" from being generated

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -786,19 +786,19 @@ for my $ofile (@args) {
     ($file, $name, $source, $version) = (undef, undef, undef, undef);
     ($content, $summary, $description, $author, $license) = (undef, undef, undef, undef, undef);
 
-    if ($ofile =~ /^(?:.*\/)?(.*)-(?:v\.?)?([^-]+)\.(tar)\.(?:gz|bz2)$/i) {
+    if ($ofile =~ /^(?:.*\/)?(.+)-(?:v\.?)?([^-]+)\.(tar)\.(?:gz|bz2)$/i) {
         $file    = $ofile;
         $name    = $1;
         $version = $2;
         $type    = $3;
     }
-    elsif ($ofile =~ /^(?:.*\/)?(.*)-(?:v\.?)?([^-]+)\.tgz$/i) {
+    elsif ($ofile =~ /^(?:.*\/)?(.+)-(?:v\.?)?([^-]+)\.tgz$/i) {
         $file    = $ofile;
         $name    = $1;
         $version = $2;
         $type    = 'tar';
     }
-    elsif ($ofile =~ /^(?:.*\/)?(.*)-(?:v\.?)?([^-]+)\.(zip)$/i) {
+    elsif ($ofile =~ /^(?:.*\/)?(.+)-(?:v\.?)?([^-]+)\.(zip)$/i) {
         $file    = $ofile;
         $name    = $1;
         $version = $2;
@@ -811,6 +811,7 @@ for my $ofile (@args) {
         # Look up $file in 02packages.details.txt.
         get_file($ofile);
     }
+    next unless $name;
 
     my $module = $name;
     $module =~ s/-/::/g;


### PR DESCRIPTION
There are multiple issues here. First, the regular expressions for
extracting package names from tarballs use "(.*)" instead of "(.+)".
And second, the `get_file` function prints a message indicating that
it will skip files it can't find, but then happily proceeds to generate
invalid spec and changes files.

Yes, the `next` alone should take care of the problem too. But i
think it makes sense to be as defensive as possible considering
the lack of tests.