### PR TITLE
Skip directories when unpacking archive

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -201,6 +201,7 @@ BEGIN {
 use Module::CoreList;
 use FileHandle;
 use Archive::Tar;
+use Archive::Tar::Constant qw/ &DIR /;
 use Archive::Zip qw(:ERROR_CODES);
 use POSIX;
 use locale;
@@ -853,6 +854,7 @@ for my $ofile (@args) {
         my $next = Archive::Tar->iter($f, 1, {prefix => "/tmp/tar"});
 
         while (my $f = $next->()) {
+            next if $f->type == DIR;
             push(@archive_files, $f->full_path);
             $f->extract($basedir . $f->full_path) or warn "Extraction failed " . $f->full_path;
         }


### PR DESCRIPTION
e.g. instead of having:

    LibYAML
    LibYAML/XS.xs
    LibYAML/api.c

we now skip the first entry:

    LibYAML/XS.xs
    LibYAML/api.c

The problem was that the `LibYAML` directory ended up in %doc, and obs
failed because this directory contained compiled c code (after the build).


```
[   57s] perl-YAML-LibYAML.x86_64: W: zero-length /usr/share/doc/packages/perl-YAML-LibYAML/LibYAML/LibYAML.bs
[   57s] perl-YAML-LibYAML.x86_64: W: zero-length /usr/share/doc/packages/perl-YAML-LibYAML/LibYAML/pm_to_blib
[   57s] perl-YAML-LibYAML.x86_64: E: arch-dependent-file-in-usr-share (Badness: 590) /usr/share/doc/packages/perl-YAML-LibYAML/LibYAML/LibYAML.o
[   57s] perl-YAML-LibYAML.x86_64: E: arch-dependent-file-in-usr-share (Badness: 590) /usr/share/doc/packages/perl-YAML-LibYAML/LibYAML/api.o
[   58s] perl-YAML-LibYAML.x86_64: E: arch-dependent-file-in-usr-share (Badness: 590) /usr/share/doc/packages/perl-YAML-LibYAML/LibYAML/dumper.o
```