### PR TITLE
Exclude editor backup files that end with '~'

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -936,6 +936,7 @@ for my $ofile (@args) {
                 !/\//
             and !/\.(pl|xs|h|c|pm|ini?|pod|cfg|inl|bak|spec)$/i
             and !/^\./
+            and !/~$/
             and $_ ne $path
             and $_ ne "MANIFEST"
             and $_ ne "MANIFEST.SKIP"


### PR DESCRIPTION
See
https://build.opensuse.org/package/show/devel:languages:perl:CPAN-F/perl-File-Find-Object
https://build.opensuse.org/package/show/devel:languages:perl:autoupdate/perl-File-Find-Object

Build fails because rpm complains about dist.ini~, Changes~ etc.

