### PR TITLE
Switch Group: line to newer tag proposal

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1298,8 +1298,8 @@ END
     print $spec <<END;
 %define cpan_name $name
 Summary:        $summary
-Url:            $url
-Group:          Development/Libraries/Perl
+URL:            $url
+Group:          development perl
 END
     my $sfile = basename($ofile);
     $sfile =~ s/$name/\%{cpan_name}/;


### PR DESCRIPTION
"Classic groups" (with the slash separator) put a package in one
group, which has been regarded as a limitation. A tag-based approach
is instead able to do a multi-group placement similar to XDG
categories. This commit moves cpanspec to emit this new syntax,
starting off with the two tags "development" and "perl" (similar to,
but not the same as the classic group Development/Languages/Perl),
dropping the unspecific "languages" tag ("perl" is a better fit).