### PR TITLE
Modernize spec

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1297,6 +1297,7 @@ END
     my $version_string = '%{version}';
 
     print $spec <<END;
+%define cpan_name $name
 Name:           $prefix$name
 Version:        $rpm_version
 Release:        $release
@@ -1325,7 +1326,6 @@ END
         print $spec "License:   $license\n";
     }
     print $spec <<END;
-%define cpan_name $name
 Summary:        $summary
 Url:            $url
 END

--- a/cpanspec
+++ b/cpanspec
@@ -1328,7 +1328,6 @@ END
 %define cpan_name $name
 Summary:        $summary
 Url:            $url
-Group:          Development/Libraries/Perl
 END
     my $sfile = basename($ofile);
     $sfile =~ s/$name/\%{cpan_name}/;
@@ -1375,7 +1374,6 @@ END
     else {
         printf $spec "%-16s%s\n", "BuildArch:", "noarch" if $noarch;
     }
-    print $spec "BuildRoot:      \%{_tmppath}/\%{name}-\%{version}-build\n";
 
     printf $spec "%-16s%s\n", "BuildRequires:", "perl";
     printf $spec "%-16s%s\n", "BuildRequires:", "perl-macros";
@@ -1628,7 +1626,6 @@ END
     }
 
     print $spec "\%files -f \%{name}.files\n";
-    print $spec "\%defattr(-,root,root,755)\n";
 
     if (%hdoc) {
 	my (@ldoc, @hdoc);

--- a/cpanspec
+++ b/cpanspec
@@ -1474,19 +1474,42 @@ END
 $description
 
 \%prep
-\%setup -q@{[($noprefix ? "" : " -n $buildpath")]}
+END
+
+    my $all_patch_args_same = 1;
+    my $common_patch_args = undef;
+    if ($config->{patches}) {
+        for my $p (sort keys %{$config->{patches}}) {
+            my $args = $config->{patches}->{$p} || undef;
+            $args =~ s/ ?PATCH-FIX.*// if defined($args);
+            if (!defined($common_patch_args) && defined($args)) {
+                $common_patch_args = $args;
+            }
+            $all_patch_args_same = ($args // '') eq ($common_patch_args // '');
+            last if !$all_patch_args_same;
+        }
+    }
+
+    my $autosetup_arg = (!$config->{patches} || $all_patch_args_same) ? (defined($common_patch_args) ? " $common_patch_args" : "") : " -N";
+        print $spec <<END;
+\%autosetup @{[($noprefix ? "" : " -n $buildpath")]}$autosetup_arg
 END
 
     if ($execs) {
         print $spec qq{find . -type f ! -path "*/t/*" ! -name "*.pl" ! -path "*/bin/*" ! -path "*/script/*" ! -name "configure" -print0 | xargs -0 chmod 644\n};
     }
 
-    if ($config->{patches}) {
+    if ($config->{patches} && !$all_patch_args_same) {
         my $counter = 0;
         for my $p (sort keys %{$config->{patches}}) {
-            my $args = $config->{patches}->{$p} || '';
-            $args =~ s/ ?PATCH-FIX.*//;
-            print $spec "%patch$counter $args\n";
+
+            my $args = $config->{patches}->{$p} || undef;
+            if (defined($args)) {
+                $args =~ s/ ?PATCH-FIX.*//;
+                print $spec "%patch$counter $args\n";
+            } else {
+                print $spec "%patch$counter\n";
+            }
             $counter++;
         }
     }

--- a/cpanspec
+++ b/cpanspec
@@ -1554,7 +1554,7 @@ END
               if ($compat and !$noarch);
 
             print $spec <<END;
-$cmdmake \%{?_smp_mflags}
+\%make_build
 
 END
         }

--- a/cpanspec.yml
+++ b/cpanspec.yml
@@ -10,6 +10,7 @@
 #patches:
 #  foo.patch: -p1
 #  bar.patch:
+#  baz.patch: PATCH-FIX-OPENSUSE
 #preamble: |-
 # BuildRequires:  gcc-c++
 #post_prep: |-


### PR DESCRIPTION
Collection of small fixes:
- remove obsolete spec file entries like the group tag
- switch to more modern macros like `%make_build` and `%autosetup`