### PR TITLE
Read BUILD_REQUIRES and TEST_REQUIRES from Makefile.PL

### DIFF
--- a/lib/Intrusive.pm
+++ b/lib/Intrusive.pm
@@ -72,6 +72,9 @@ sub _find_modules {
     my $WriteMakefile = sub {
         my %args = @_;
         $self->requires( $args{PREREQ_PM} || {} );
+        my %br = %{ $args{TEST_REQUIRES} || {} };
+        %br = (%br, %{ $args{BUILD_REQUIRES} }) if $args{BUILD_REQUIRES};
+        $self->build_requires( \%br );
         1;
     };
     local *main::WriteMakefile;


### PR DESCRIPTION
BUILD_REQUIRES and TEST_REQUIRES are relatively (!) new arguments to ExtUtils::MakeMaker::WriteMakefile. So far they were ignored.

Related to #21 

This has been tested during the last few days on the host running the autoupdates https://build.opensuse.org/project/show/devel:languages:perl:autoupdate