### PR TITLE
Read from META.json and more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM opensuse/leap:15.2
+
+RUN zypper refresh \
+    && zypper install -y \
+        osc \
+        perl \
+        perl-YAML-LibYAML \
+        perl-XML-Simple \
+        perl-Parse-CPAN-Packages \
+        procmail \
+        wget \
+        vim \
+        git \
+        perl-Text-Autoformat \
+        perl-YAML \
+        perl-Pod-POM \
+        perl-libwww-perl \
+        perl-Class-Accessor-Chained \
+        perl-Perl-PrereqScanner \
+        perl-Algorithm-Diff \
+        perl-Module-Build-Tiny \
+        perl-ExtUtils-Depends \
+        perl-ExtUtils-PkgConfig \
+        obs-service-format_spec_file \
+    && true
+
+
+RUN cd /tmp && wget http://www.cpan.org/modules/02packages.details.txt.gz
+
+ENV LANG=en_US.UTF-8 \
+    LC_CTYPE="en_US.UTF-8" \
+    LC_NUMERIC="en_US.UTF-8" \
+    LC_TIME="en_US.UTF-8" \
+    LC_COLLATE="en_US.UTF-8"
+
+
+# perl /cpanspec/cpanspec -v -f --skip-changes --pkgdetails /tmp/02packages.details.txt.gz tarball
+

--- a/bin/batch.pl
+++ b/bin/batch.pl
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use 5.010;
+use Data::Dumper;
+use Getopt::Long;
+
+GetOptions(
+    "debug" => \my $debug,
+    "dry" => \my $dry,
+    "help|h" => \my $help,
+)   # flag
+or die "Error in command line arguments";
+
+if ($help) {
+    print <<'EOM';
+Usage:
+    batch.pl /path/to/packages 0 50 # process the first 51 packages
+EOM
+    exit;
+}
+
+my ($dir, $from, $to) = @ARGV;
+$from ||= 0;
+$to ||= $from;
+
+my @skip = qw/
+    perl-AcePerl
+    perl-Acme-MetaSyntactic
+    perl-Acme-Ook
+    perl-Algorithm-Munkres
+    perl-Alien-LibGumbo
+    perl-Alien-SVN
+    perl-Alien-Tidyp
+    perl-Apache-AuthNetLDAP
+    perl-Apache-Filter
+    perl-Apache-SessionX
+    perl-Apache-Gallery
+    perl-App-ProcIops
+    perl-App-Nopaste
+    perl-App-SVN-Bisect
+    perl-App-gcal
+    perl-Array-Dissect
+    perl-Audio-CD
+    perl-Authen-SASL-Cyrus
+    perl-BIND-Conf_Parser
+    perl-BSXML
+    perl-Boost-Geometry-Utils
+    perl-Class-Accessor-Chained
+    Class-Multimethods
+    perl-Crypt-HSXKPasswd
+    perl-Crypt-Rot13
+/;
+my %skip;
+@skip{ @skip } = ();
+
+opendir my $dh, $dir or die $!;
+my @pkgs = sort grep {
+    -d "$dir/$_" && m/^perl-/
+    and not exists $skip{ $_ }
+} readdir $dh;
+closedir $dh;
+
+my $count = @pkgs;
+say "Total: $count";
+
+my $opt_debug = $debug ? '--debug' : '';
+for my $i ($from .. $to) {
+    my $pkg = $pkgs[ $i ];
+    chdir $dir;
+    say "=========== ($i) $pkg";
+    next if $dry;
+    chdir $pkg;
+    my $mod = $pkg;
+    $mod =~ s/^perl-//;
+    my @glob = glob("$mod*");
+    my $cmd = qq{cpanspec $opt_debug -v -f --skip-changes --pkgdetails /tmp/02packages.details.txt.gz @glob 2>&1};
+    say "Cmd: $cmd";
+    my $out = qx{$cmd};
+    say $out;
+
+}

--- a/bin/intrusive.pl
+++ b/bin/intrusive.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use 5.010;
+use JSON::PP;
+use File::Basename qw/ dirname /;
+my $bin = dirname(__FILE__);
+require "$bin/../lib/Intrusive.pm";
+
+my $coder = JSON::PP->new->utf8->pretty->canonical;
+
+my ($path) = @ARGV;
+
+my $deps = Intrusive->new->dist_dir($path)->find_modules;
+
+my $json = $coder->encode({%$deps});
+print $json;
+

--- a/bin/intrusive.pl
+++ b/bin/intrusive.pl
@@ -11,7 +11,15 @@ my $coder = JSON::PP->new->utf8->pretty->canonical;
 
 my ($path) = @ARGV;
 
+# Makefile.PL etc. might print things to STDOUT, temporary redirect
+# to STDERR
+open my $orig, ">&", STDOUT;
+open STDOUT, ">&STDERR";
+
 my $deps = Intrusive->new->dist_dir($path)->find_modules;
+
+# restore STDOUT
+open STDOUT, ">&", $orig;
 
 my $json = $coder->encode({%$deps});
 print $json;

--- a/cpanspec
+++ b/cpanspec
@@ -227,6 +227,7 @@ use JSON::PP ();
 
 require Carp;
 
+my $url="https://metacpan.org/release/\%{cpan_name}";
 my $bin = Cwd::abs_path(dirname($script));
 my $coder = JSON::PP->new->utf8;
 
@@ -885,6 +886,7 @@ for my $ofile (@args) {
         push(@archive_files, $archive->memberNames());
     }
 
+    my %stats;
     my @files = ();
     my $bogus = 0;
     my $execs = 0;
@@ -893,6 +895,7 @@ for my $ofile (@args) {
     @archive_files = sort @archive_files;
     my $changesfile;
     foreach my $entry (@archive_files) {
+
         my $version0=$version;
         $version0=~s/0*$/0*/; # pathnames may not contain as many trailing zeros
         if (
@@ -932,8 +935,6 @@ for my $ofile (@args) {
         next;
     }
 
-    my $url="https://metacpan.org/release/\%{cpan_name}";
-
     get_source($name) if(!defined $source && -d dirname($pkgdetails));
 
     $content = get_content(
@@ -950,7 +951,6 @@ for my $ofile (@args) {
     }
 
     $summary = get_summary($summary, $content, $module) unless defined $summary;
-    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$summary], ['summary']);
 
     get_author($content) if (!defined($author));
 
@@ -1096,7 +1096,6 @@ for my $ofile (@args) {
     my $metayaml = -e "$basedir/$path/META.yml" ? 1 : '';
     my $metajson = -e "$basedir/$path/META.json" ? 1 : '';
     my $dynamic = 1;
-    warn "META.json: $metajson META.yml: $metayaml";
     my $got_prereqs = 0;
 
     if ($metajson) {
@@ -1106,8 +1105,10 @@ for my $ofile (@args) {
         $metajson = eval { $coder->decode($json) };
         if ($@) {
             warn "Error decoding META.json, ignoring ($@)";
+            $stats{metajson} = 'error';
         }
         else {
+            $stats{metajson} = 1;
             if (exists $metajson->{dynamic_config} and not $metajson->{dynamic_config}) {
                 $dynamic = 0;
             }
@@ -1121,28 +1122,35 @@ for my $ofile (@args) {
                 %requires = %$run;
                 %recommends = %$rec;
                 $got_prereqs = 1;
-                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
-                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
-                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
+                if ($debug) {
+                    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
+                    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
+                    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
+                }
+            }
+            $stats{license}->{metajson} = $metajson->{license};
+            if ($metajson->{abstract}) {
+                $stats{abstract}->{metajson} = $metajson->{abstract};
             }
         }
     }
-
-    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$got_prereqs], ['got_prereqs']);
 
     if ($metayaml) {
         my $yml = readfile("$path/META.yml");
         my $meta = eval { Load($yml); };
         if ($@) {
             warn "Error parsing $path/META.yml: $@";
+            $stats{metayaml} = 'error';
             goto SKIP;
         }
+        $stats{metayaml} = 1;
         if (exists $meta->{dynamic_config} and not $meta->{dynamic_config}) {
             $dynamic = 0;
         }
 
         if ($meta->{abstract} && $meta->{abstract} ne 'unknown') {
             my $abstract = $meta->{abstract};
+            $stats{abstract}->{metayaml} = $abstract;
             $summary = $abstract unless defined $summary;
         }
 
@@ -1156,17 +1164,20 @@ for my $ofile (@args) {
             %requires = %$run;
             %recommends = %$rec;
             $got_prereqs = 1;
-            warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
-            warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
-            warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
+            if ($debug) {
+                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
+                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
+                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
+            }
         }
-        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$got_prereqs], ['got_prereqs']);
+        $stats{got_prereqs} = $got_prereqs; # did we get static dependencies?
 
         # FIXME - I'm not sure this is sufficient...
         if ($meta->{script_files} or $meta->{scripts}) {
             $scripts = 1;
         }
 
+        $stats{license}->{metayaml} = $meta->{license};
         if ($meta->{license}) {
             # This list of licenses is from the Module::Build::API
             # docs, cross referenced with the list of licenses in
@@ -1220,7 +1231,8 @@ for my $ofile (@args) {
         }
       SKIP:
     }
-    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$dynamic], ['dynamic']);
+    $stats{dynamic} = $dynamic;
+    $debug and warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$dynamic], ['dynamic']);
 
     if (!defined($license)) {
         get_license($content);
@@ -1240,8 +1252,10 @@ for my $ofile (@args) {
     }
 
     $license = "CHECK($perllicense)" if (!$license);
+    $stats{license}->{spec} = $license;
 
     $description = $summary if (!defined($description));
+    $stats{summary} = $summary;
 
     $summary =~ s,\.$,,;
     $summary =~ s,^[aA] ,,;
@@ -1277,7 +1291,7 @@ for my $ofile (@args) {
     }
 
     if ($got_prereqs and not $dynamic) {
-        warn "Got prereqs, no need to run Makefile.PL/Build.PL";
+        $debug and warn "Got prereqs, no need to run Makefile.PL/Build.PL";
     }
     else {
         # Basic idea borrowed from Module::Depends.
@@ -1301,9 +1315,10 @@ for my $ofile (@args) {
         }
     }
 
-    my $provides = keys %provides;
-    warn "########## PROVIDES: $provides\n";
+    $stats{provides} = keys %provides;
+    dump_statistics($module, $version, \%stats);
     unless (%provides) {
+        verbose("No 'provides' info in meta, parsing code.\n");
         %provides = parse_provides($basedir . $path, \@files);
     }
 
@@ -1886,6 +1901,16 @@ sub decode_latin_or_utf8 {
     #my $name = $enc->name;
     $string = $enc->decode($string);
     return $string;
+}
+
+sub dump_statistics {
+    my ($module, $version, $stats) = @_;
+    $stats->{name} = $module;
+    $stats->{version} = $version;
+    my $yaml = YAML::XS::Dump($stats);
+    $yaml =~ s/^/# STATS # /mg;
+    $yaml = "# STATS # # $module, $version\n$yaml";
+    verbose($yaml);
 }
 
 # vi: set ai et:

--- a/cpanspec
+++ b/cpanspec
@@ -1277,38 +1277,13 @@ for my $ofile (@args) {
     my $provides = keys %provides;
     $debug and say "########## PROVIDES: $provides\n";
     unless (%provides) {
-
-        my $scanner = Perl::PrereqScanner->new;
-        foreach my $test (grep /\.(pm|t|PL|pl)/, @files) {
-            my $doc = PPI::Document->new($basedir . $path . "/" . $test);
-
-            next unless ($doc);
-
-            # Get the name of the main package
-            my $pkg = $doc->find_first('PPI::Statement::Package');
-            if ($pkg) {
-                $provides{$pkg->namespace} = 1;
-            }
-
-#            my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
-#            next unless $scan;
-#            my %scanneddeps = %$scan;
-#            foreach my $dep (keys(%scanneddeps)) {
-#                my $ndep = $scanneddeps{$dep};
-#                unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
-#                    $possible_build_requires{$dep} = $scanneddeps{$dep};
-#                }
-#            }
-        }
+        %provides = parse_provides($basedir . $path, \@files);
     }
 
-    foreach my $pkg (keys %provides) { delete $build_requires{$pkg} }
-
+    delete @build_requires{ keys %provides };
     my %hdoc;
-    if (@doc) {
-        foreach my $d (@doc) {
-            $hdoc{$d} = 1;
-        }
+    foreach my $d (@doc) {
+        $hdoc{$d} = 1;
     }
 
     rmtree($basedir);
@@ -1779,6 +1754,34 @@ END
         die "osc vc failed with $?" if $?;
         close($tfh);
     }
+}
+
+sub parse_provides {
+    my ($path, $files) = @_;
+    my %provides;
+    my $scanner = Perl::PrereqScanner->new;
+    foreach my $test (grep /\.(pm|t|PL|pl)/, @$files) {
+        my $doc = PPI::Document->new($path . "/" . $test);
+
+        next unless ($doc);
+
+        # Get the name of the main package
+        my $pkg = $doc->find_first('PPI::Statement::Package');
+        if ($pkg) {
+            $provides{$pkg->namespace} = 1;
+        }
+
+#        my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
+#        next unless $scan;
+#        my %scanneddeps = %$scan;
+#        foreach my $dep (keys(%scanneddeps)) {
+#            my $ndep = $scanneddeps{$dep};
+#            unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
+#                $possible_build_requires{$dep} = $scanneddeps{$dep};
+#            }
+#        }
+    }
+    return %provides;
 }
 
 sub decode_latin_or_utf8 {

--- a/cpanspec
+++ b/cpanspec
@@ -1103,24 +1103,29 @@ for my $ofile (@args) {
         open my $fh, '<', "$basedir/$path/META.json" or die $!;
         my $json = do { local $/; <$fh> };
         close $fh;
-        $metajson = $coder->decode($json);
-        unless ($metajson->{dynamic_config}) {
-            $dynamic = 0;
+        $metajson = eval { $coder->decode($json) };
+        if ($@) {
+            warn "Error decoding META.json, ignoring ($@)";
         }
+        else {
+            if (exists $metajson->{dynamic_config} and not $metajson->{dynamic_config}) {
+                $dynamic = 0;
+            }
 
-        my ($prov, $build, $run, $rec) = prereqs_from_metajson($metajson);
-        if (keys %$prov) {
-            @provides{ keys %$prov } = values %$prov;
+            my ($prov, $build, $run, $rec) = prereqs_from_metajson($metajson);
+            if (keys %$prov) {
+                @provides{ keys %$prov } = values %$prov;
+            }
+            if ($build) {
+                %build_requires = %$build;
+                %requires = %$run;
+                %recommends = %$rec;
+                $got_prereqs = 1;
+                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
+                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
+                warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
+            }
         }
-        if ($build) {
-            %build_requires = %$build;
-            %requires = %$run;
-            %recommends = %$rec;
-            $got_prereqs = 1;
-        }
-        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
-        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
-        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
     }
 
     warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$got_prereqs], ['got_prereqs']);
@@ -1132,7 +1137,7 @@ for my $ofile (@args) {
             warn "Error parsing $path/META.yml: $@";
             goto SKIP;
         }
-        unless ($meta->{dynamic_config}) {
+        if (exists $meta->{dynamic_config} and not $meta->{dynamic_config}) {
             $dynamic = 0;
         }
 

--- a/cpanspec
+++ b/cpanspec
@@ -191,6 +191,7 @@ use 5.010;
 
 our $NAME    = "cpanspec";
 our $VERSION = '1.80.01';
+my $script = __FILE__;
 
 use Cwd;
 BEGIN {
@@ -219,13 +220,15 @@ use LWP::UserAgent;
 use Parse::CPAN::Packages;
 use File::Temp;
 use File::Path qw(rmtree);
-use Intrusive;
 use Perl::PrereqScanner;
 use Encode qw/ decode_utf8 /;
 use Encode::Guess;
 use JSON::PP ();
 
 require Carp;
+
+my $bin = Cwd::abs_path(dirname($script));
+my $coder = JSON::PP->new->utf8;
 
 our %opt;
 
@@ -1095,8 +1098,7 @@ for my $ofile (@args) {
         open my $fh, '<', "$basedir/$path/META.json" or die $!;
         my $json = do { local $/; <$fh> };
         close $fh;
-        my $decoder = JSON::PP->new->utf8;
-        $metajson = $decoder->decode($json);
+        $metajson = $coder->decode($json);
         unless ($metajson->{dynamic_config}) {
             $dynamic = 0;
         }
@@ -1257,13 +1259,14 @@ for my $ofile (@args) {
         $build_requires{'ExtUtils::MakeMaker'} = 0;
     }
 
-    my $deps      = Intrusive->new->dist_dir($basedir . $path)->find_modules;
-    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$deps], ['deps']);
-    my %lrequires = %{$deps->requires};
+    my $intrusive = qq{perl $bin/bin/intrusive.pl $basedir$path};
+    my $jsondeps = qx{$intrusive};
+    my $deps = $coder->decode($jsondeps);
+    my %lrequires = %{ $deps->{requires} };
     foreach my $dep (keys(%lrequires)) {
         $requires{$dep} = $lrequires{$dep};
     }
-    %lrequires = %{$deps->build_requires};
+    %lrequires = %{ $deps->{build_requires} };
     foreach my $dep (keys(%lrequires)) {
         if (defined $build_requires{$dep}) {
             next if version->parse($build_requires{$dep}) > version->parse($lrequires{$dep});

--- a/cpanspec
+++ b/cpanspec
@@ -1283,7 +1283,11 @@ for my $ofile (@args) {
         # Basic idea borrowed from Module::Depends.
         my $intrusive = qq{perl $bin/bin/intrusive.pl $basedir$path};
         my $jsondeps = qx{$intrusive};
-        my $deps = $coder->decode($jsondeps);
+        my $deps = eval { $coder->decode($jsondeps) };
+        unless ($deps) {
+            warn "JSON: >>$jsondeps<<";
+            die $@;
+        }
         my %lrequires = %{ $deps->{requires} };
         foreach my $dep (keys(%lrequires)) {
             $requires{$dep} = $lrequires{$dep};

--- a/cpanspec
+++ b/cpanspec
@@ -1256,15 +1256,15 @@ for my $ofile (@args) {
             $packages{$pkg->namespace} = 1;
         }
 
-	my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
-	next unless $scan;
-	my %scanneddeps = %$scan; 
-	foreach my $dep (keys(%scanneddeps)) {
-	    my $ndep = $scanneddeps{$dep};
-	    unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
-                $possible_build_requires{$dep} = $scanneddeps{$dep};
-            }
-        }
+#        my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
+#        next unless $scan;
+#        my %scanneddeps = %$scan;
+#        foreach my $dep (keys(%scanneddeps)) {
+#            my $ndep = $scanneddeps{$dep};
+#            unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
+#                $possible_build_requires{$dep} = $scanneddeps{$dep};
+#            }
+#        }
     }
 
     foreach my $pkg (keys %packages) { delete $build_requires{$pkg} }

--- a/cpanspec
+++ b/cpanspec
@@ -187,6 +187,7 @@ L<perl(1)>, L<cpan2rpm(1)>, L<cpanflute2(1)>
 
 use strict;
 use warnings;
+use 5.010;
 
 our $NAME    = "cpanspec";
 our $VERSION = '1.80.01';
@@ -222,6 +223,7 @@ use Intrusive;
 use Perl::PrereqScanner;
 use Encode qw/ decode_utf8 /;
 use Encode::Guess;
+use JSON::PP ();
 
 require Carp;
 
@@ -250,6 +252,7 @@ our $config_file;
 our $old_file;
 our $config = {};
 our $cpan = $ENV{'CPAN'} || 'https://cpan.metacpan.org';
+my $debug;
 
 our $home = $ENV{'HOME'} || (getpwuid($<))[7];
 die "Can't locate home directory.  Please define \$HOME.\n"
@@ -770,6 +773,7 @@ GetOptions(
     'version'             => \&print_version,
     'prefer-macros|m'     => \$macros,
     'pkgdetails=s'        => \$pkgdetails,
+    'debug'               => \$debug,
 ) or pod2usage({-exitval => 1, -verbose => 0});
 
 pod2usage({-exitval => 0, -verbose => 1}) if ($help);
@@ -1083,8 +1087,27 @@ for my $ofile (@args) {
 
     my $scripts = 0;
     my (%build_requires, %requires, %recommends, %possible_build_requires);
-    my ($yml, $meta);
-    if (grep /^META\.yml$/, @files and $yml = readfile("$path/META.yml")) {
+    my %provides;
+    my ($meta, $metajson);
+    my $dynamic = 1;
+
+    if (grep { $_ eq 'META.json' } @files) {
+        open my $fh, '<', "$basedir/$path/META.json" or die $!;
+        my $json = do { local $/; <$fh> };
+        close $fh;
+        my $decoder = JSON::PP->new->utf8;
+        $metajson = $decoder->decode($json);
+        unless ($metajson->{dynamic_config}) {
+            $dynamic = 0;
+        }
+        if ($metajson->{provides}) {
+            for my $pkg (keys %{ $metajson->{provides} || {} }) {
+                $provides{ $pkg } = 1;
+            }
+        }
+    }
+
+    if (grep /^META\.yml$/, @files and my $yml = readfile("$path/META.yml")) {
         # Basic idea borrowed from Module::Depends.
         my $meta;
         eval { $meta = Load($yml); };
@@ -1172,6 +1195,11 @@ for my $ofile (@args) {
                 warn "Unknown license in meta '" . $meta->{license} . "'!\n";
             }
         }
+        if (not %provides and $meta->{provides}) {
+            for my $pkg (keys %{ $meta->{provides} || {} }) {
+                $provides{ $pkg } = 1;
+            }
+        }
       SKIP:
     }
 
@@ -1230,6 +1258,7 @@ for my $ofile (@args) {
     }
 
     my $deps      = Intrusive->new->dist_dir($basedir . $path)->find_modules;
+    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$deps], ['deps']);
     my %lrequires = %{$deps->requires};
     foreach my $dep (keys(%lrequires)) {
         $requires{$dep} = $lrequires{$dep};
@@ -1242,32 +1271,35 @@ for my $ofile (@args) {
         $build_requires{$dep} = $lrequires{$dep};
     }
 
-    my %packages = ();
+    my $provides = keys %provides;
+    $debug and say "########## PROVIDES: $provides\n";
+    unless (%provides) {
 
-    my $scanner = Perl::PrereqScanner->new;
-    foreach my $test (grep /\.(pm|t|PL|pl)/, @files) {
-        my $doc = PPI::Document->new($basedir . $path . "/" . $test);
+        my $scanner = Perl::PrereqScanner->new;
+        foreach my $test (grep /\.(pm|t|PL|pl)/, @files) {
+            my $doc = PPI::Document->new($basedir . $path . "/" . $test);
 
-        next unless ($doc);
+            next unless ($doc);
 
-        # Get the name of the main package
-        my $pkg = $doc->find_first('PPI::Statement::Package');
-        if ($pkg) {
-            $packages{$pkg->namespace} = 1;
-        }
+            # Get the name of the main package
+            my $pkg = $doc->find_first('PPI::Statement::Package');
+            if ($pkg) {
+                $provides{$pkg->namespace} = 1;
+            }
 
-#        my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
-#        next unless $scan;
-#        my %scanneddeps = %$scan;
-#        foreach my $dep (keys(%scanneddeps)) {
-#            my $ndep = $scanneddeps{$dep};
-#            unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
-#                $possible_build_requires{$dep} = $scanneddeps{$dep};
+#            my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
+#            next unless $scan;
+#            my %scanneddeps = %$scan;
+#            foreach my $dep (keys(%scanneddeps)) {
+#                my $ndep = $scanneddeps{$dep};
+#                unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
+#                    $possible_build_requires{$dep} = $scanneddeps{$dep};
+#                }
 #            }
-#        }
+        }
     }
 
-    foreach my $pkg (keys %packages) { delete $build_requires{$pkg} }
+    foreach my $pkg (keys %provides) { delete $build_requires{$pkg} }
 
     my %hdoc;
     if (@doc) {

--- a/cpanspec
+++ b/cpanspec
@@ -1091,7 +1091,7 @@ for my $ofile (@args) {
     $license = undef;
 
     my $scripts = 0;
-    my (%build_requires, %requires, %recommends, %possible_build_requires);
+    my (%build_requires, %requires, %recommends);
     my %provides;
     my $metayaml = -e "$basedir/$path/META.yml" ? 1 : '';
     my $metajson = -e "$basedir/$path/META.json" ? 1 : '';
@@ -1442,9 +1442,6 @@ END
     }
 
     my @treqs = sort(keys(%build_requires));
-    foreach my $dep (sort(keys(%possible_build_requires))) {
-        push(@treqs, $dep) if (!defined $build_requires{$dep});
-    }
     for my $dep (@treqs) {
         my $iscore = 0;
         eval { $iscore = is_in_core($dep, $build_requires{$dep}); };
@@ -1840,7 +1837,6 @@ sub prereqs_from_metajson {
     }
 
     my $prereqs = $metajson->{prereqs};
-#    delete $prereqs->{develop};
     return (\%provides) unless keys %$prereqs;
 
     for my $phase (qw/ build configure test /) {
@@ -1879,15 +1875,6 @@ sub parse_provides {
             $provides{$pkg->namespace} = 1;
         }
 
-#        my $scan; # = eval { $scanner->scan_ppi_document($doc)->as_string_hash; };
-#        next unless $scan;
-#        my %scanneddeps = %$scan;
-#        foreach my $dep (keys(%scanneddeps)) {
-#            my $ndep = $scanneddeps{$dep};
-#            unless ($build_requires{$dep} && version->parse($build_requires{$dep}) > version->parse($ndep)) {
-#                $possible_build_requires{$dep} = $scanneddeps{$dep};
-#            }
-#        }
     }
     return %provides;
 }

--- a/cpanspec
+++ b/cpanspec
@@ -547,9 +547,8 @@ sub get_description {
     return $description = undef;
 }
 
-sub get_summary($$) {
-    my $cont   = shift;
-    my $mod    = shift;
+sub get_summary {
+    my ($summary, $cont, $mod) = @_;
     my $parser = Pod::POM->new;
 
     # extract pod; the file may contain no pod, that's ok
@@ -564,7 +563,7 @@ sub get_summary($$) {
         $pom =~ /^[^-]+ -* (.*)$/m;
 
         # return...
-        return $summary = $1 if $pom;
+        return "$1" if $1;
     }
     return $summary;
 }
@@ -804,13 +803,15 @@ for my $r (split(/ /, $config->{ignore_requires} || '')) {
 }
 my @args      = @ARGV;
 my @processed = ();
+local $Data::Dumper::Sortkeys = 1;
 
 for my $ofile (@args) {
 
     my $type = undef;
     my $download = undef;
+    my $summary;
     ($file, $name, $source, $version) = (undef, undef, undef, undef);
-    ($content, $summary, $description, $author, $license) = (undef, undef, undef, undef, undef);
+    ($content, $description, $author, $license) = (undef, undef, undef, undef);
 
     if ($ofile =~ /^(?:.*\/)?(.+)-(?:v\.?)?([^-]+)\.(tar)\.(?:gz|bz2)$/i) {
         $file    = $ofile;
@@ -948,7 +949,8 @@ for my $ofile (@args) {
 	get_description($content) || get_description($content, 'OVERVIEW');
     }
 
-    get_summary($content,$module) if (!defined($summary));
+    $summary = get_summary($summary, $content, $module) unless defined $summary;
+    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$summary], ['summary']);
 
     get_author($content) if (!defined($author));
 
@@ -1091,10 +1093,13 @@ for my $ofile (@args) {
     my $scripts = 0;
     my (%build_requires, %requires, %recommends, %possible_build_requires);
     my %provides;
-    my ($meta, $metajson);
+    my $metayaml = -e "$basedir/$path/META.yml" ? 1 : '';
+    my $metajson = -e "$basedir/$path/META.json" ? 1 : '';
     my $dynamic = 1;
+    warn "META.json: $metajson META.yml: $metayaml";
+    my $got_prereqs = 0;
 
-    if (grep { $_ eq 'META.json' } @files) {
+    if ($metajson) {
         open my $fh, '<', "$basedir/$path/META.json" or die $!;
         my $json = do { local $/; <$fh> };
         close $fh;
@@ -1102,44 +1107,55 @@ for my $ofile (@args) {
         unless ($metajson->{dynamic_config}) {
             $dynamic = 0;
         }
-        if ($metajson->{provides}) {
-            for my $pkg (keys %{ $metajson->{provides} || {} }) {
-                $provides{ $pkg } = 1;
-            }
+
+        my ($prov, $build, $run, $rec) = prereqs_from_metajson($metajson);
+        if (keys %$prov) {
+            @provides{ keys %$prov } = values %$prov;
         }
+        if ($build) {
+            %build_requires = %$build;
+            %requires = %$run;
+            %recommends = %$rec;
+            $got_prereqs = 1;
+        }
+        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
+        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
+        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
     }
 
-    if (grep /^META\.yml$/, @files and my $yml = readfile("$path/META.yml")) {
-        # Basic idea borrowed from Module::Depends.
-        my $meta;
-        eval { $meta = Load($yml); };
+    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$got_prereqs], ['got_prereqs']);
+
+    if ($metayaml) {
+        my $yml = readfile("$path/META.yml");
+        my $meta = eval { Load($yml); };
         if ($@) {
             warn "Error parsing $path/META.yml: $@";
             goto SKIP;
         }
+        unless ($meta->{dynamic_config}) {
+            $dynamic = 0;
+        }
 
         if ($meta->{abstract} && $meta->{abstract} ne 'unknown') {
             my $abstract = $meta->{abstract};
-            $summary = $abstract if (!defined($summary));
+            $summary = $abstract unless defined $summary;
         }
 
-        %build_requires = %{$meta->{build_requires}} if ($meta->{build_requires});
-        if ($meta->{configure_requires}) {
-            while (my ($key, $value) = each(%{$meta->{configure_requires}})) {
-                if (defined $build_requires{$key}) {
-                    next if version->parse($build_requires{$key}) > version->parse($value);
-                }
-                $build_requires{$key} = $value;
-            }
-        }
-        if ($meta->{test_requires}) {
-            while (my ($key, $value) = each(%{$meta->{test_requires}})) {
-                $build_requires{$key} = $value;
-            }
+        my ($prov, $build, $run, $rec) = prereqs_from_metayaml($meta);
+        if (not %provides and keys %$prov) {
+            @provides{ keys %$prov } = values %$prov;
         }
 
-        %requires   = %{$meta->{requires}}   if ($meta->{requires});
-        %recommends = %{$meta->{recommends}} if ($meta->{recommends});
+        if (not $got_prereqs and $build) {
+            %build_requires = %$build;
+            %requires = %$run;
+            %recommends = %$rec;
+            $got_prereqs = 1;
+            warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%build_requires], ['build_requires']);
+            warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%requires], ['requires']);
+            warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\%recommends], ['recommends']);
+        }
+        warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$got_prereqs], ['got_prereqs']);
 
         # FIXME - I'm not sure this is sufficient...
         if ($meta->{script_files} or $meta->{scripts}) {
@@ -1197,13 +1213,9 @@ for my $ofile (@args) {
                 warn "Unknown license in meta '" . $meta->{license} . "'!\n";
             }
         }
-        if (not %provides and $meta->{provides}) {
-            for my $pkg (keys %{ $meta->{provides} || {} }) {
-                $provides{ $pkg } = 1;
-            }
-        }
       SKIP:
     }
+    warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$dynamic], ['dynamic']);
 
     if (!defined($license)) {
         get_license($content);
@@ -1256,26 +1268,32 @@ for my $ofile (@args) {
         }
     }
     else {
-        $build_requires{'ExtUtils::MakeMaker'} = 0;
+        $build_requires{'ExtUtils::MakeMaker'} ||= 0;
     }
 
-    my $intrusive = qq{perl $bin/bin/intrusive.pl $basedir$path};
-    my $jsondeps = qx{$intrusive};
-    my $deps = $coder->decode($jsondeps);
-    my %lrequires = %{ $deps->{requires} };
-    foreach my $dep (keys(%lrequires)) {
-        $requires{$dep} = $lrequires{$dep};
+    if ($got_prereqs and not $dynamic) {
+        warn "Got prereqs, no need to run Makefile.PL/Build.PL";
     }
-    %lrequires = %{ $deps->{build_requires} };
-    foreach my $dep (keys(%lrequires)) {
-        if (defined $build_requires{$dep}) {
-            next if version->parse($build_requires{$dep}) > version->parse($lrequires{$dep});
+    else {
+        # Basic idea borrowed from Module::Depends.
+        my $intrusive = qq{perl $bin/bin/intrusive.pl $basedir$path};
+        my $jsondeps = qx{$intrusive};
+        my $deps = $coder->decode($jsondeps);
+        my %lrequires = %{ $deps->{requires} };
+        foreach my $dep (keys(%lrequires)) {
+            $requires{$dep} = $lrequires{$dep};
         }
-        $build_requires{$dep} = $lrequires{$dep};
+        %lrequires = %{ $deps->{build_requires} };
+        foreach my $dep (keys(%lrequires)) {
+            if (defined $build_requires{$dep}) {
+                next if version->parse($build_requires{$dep}) > version->parse($lrequires{$dep});
+            }
+            $build_requires{$dep} = $lrequires{$dep};
+        }
     }
 
     my $provides = keys %provides;
-    $debug and say "########## PROVIDES: $provides\n";
+    warn "########## PROVIDES: $provides\n";
     unless (%provides) {
         %provides = parse_provides($basedir . $path, \@files);
     }
@@ -1754,6 +1772,72 @@ END
         die "osc vc failed with $?" if $?;
         close($tfh);
     }
+}
+
+sub prereqs_from_metayaml {
+    my ($meta) = @_;
+    my (%provides, %build_requires, %requires, %recommends);
+
+    if ($meta->{provides}) {
+        for my $pkg (keys %{ $meta->{provides} || {} }) {
+            $provides{ $pkg } = 1;
+        }
+    }
+
+    %build_requires = %{$meta->{build_requires}} if ($meta->{build_requires});
+    if ($meta->{configure_requires}) {
+        while (my ($key, $value) = each(%{$meta->{configure_requires}})) {
+            if (defined $build_requires{$key}) {
+                next if version->parse($build_requires{$key}) > version->parse($value);
+            }
+            $build_requires{$key} = $value;
+        }
+    }
+    if ($meta->{test_requires}) {
+        while (my ($key, $value) = each(%{$meta->{test_requires}})) {
+            $build_requires{$key} = $value;
+        }
+    }
+
+    %requires   = %{$meta->{requires}}   if ($meta->{requires});
+    %recommends = %{$meta->{recommends}} if ($meta->{recommends});
+    return (\%provides)
+        if (not %build_requires and not %requires and not %recommends);
+    return (\%provides, \%build_requires, \%requires, \%recommends);
+}
+
+sub prereqs_from_metajson {
+    my ($metajson) = @_;
+    my (%provides, %build, %run, %rec);
+    if ($metajson->{provides}) {
+        for my $pkg (keys %{ $metajson->{provides} || {} }) {
+            $provides{ $pkg } = 1;
+        }
+    }
+
+    my $prereqs = $metajson->{prereqs};
+#    delete $prereqs->{develop};
+    return (\%provides) unless keys %$prereqs;
+
+    for my $phase (qw/ build configure test /) {
+        if (my $build = $prereqs->{ $phase }) {
+            my $req = $build->{requires} || {};
+            for my $module (sort keys %$req) {
+                next if exists $build{ $module } and
+                    version->parse($build{ $module }) > version->parse( $req->{ $module });
+                $build{ $module } = $req->{ $module };
+            }
+        }
+    }
+    for my $phase (qw/ runtime /) {
+        if (my $build = $prereqs->{ $phase }) {
+            my $req = $build->{requires} || {};
+            @run{ keys %$req } = values %$req;
+            my $rec = $build->{recommends} || {};
+            @rec{ keys %$rec } = values %$rec;
+        }
+    }
+    return (\%provides, \%build, \%run, \%rec);
 }
 
 sub parse_provides {

--- a/lib/CPAN2OBS.pm
+++ b/lib/CPAN2OBS.pm
@@ -527,10 +527,13 @@ sub osc_update_dist {
         my $cmd = sprintf
             "timeout 180 perl $cpanspec -v -f --pkgdetails %s --skip-changes %s > cpanspec.error 2>&1",
             "$data/02packages.details.txt.gz", $tar;
+        debug("CMD $cmd");
         if (system $cmd or not -f $spec) {
             info("Error executing cpanspec");
+            system("cat cpanspec.error");
         }
         else {
+            system("cat cpanspec.error");
             $error = 0;
             unlink "cpanspec.error";
         }
@@ -668,7 +671,7 @@ sub osc_update_dist_perl {
     copy("$Bin/../cpanspec.yml", "$checkout/cpanspec.yml") unless -f "cpanspec.yml";
     {
         my $cmd = sprintf
-            "timeout 900 perl $cpanspec -f --pkgdetails %s --old-file %s %s > cpanspec.error 2>&1",
+            "timeout 900 perl $cpanspec -v -f --pkgdetails %s --old-file %s %s > cpanspec.error 2>&1",
             "$data/02packages.details.txt.gz", ".osc/$old_tar", $tar;
         debug("CMD $cmd");
         if (system $cmd or not -f $spec) {


### PR DESCRIPTION
Summary:
* Add a Dockerfile with everything necessary to run `cpanspec`
* Add reading several things from `META.json` (dependencies, `dynamic_config`, `provides`)
* Skip parsing the code if `provides` exists in `META.(json|yaml)`
* Skip calling `Makefile.PL` etc. if `dynamic_config` exists in `META.(json|yaml)` and is false
* Move the code to call `Makefile.PL` etc. into it's own subprocessto avoid influencing the result
* Fix a case where the root directory of cpanspec was added to `@INC` and a `Build.PL` of a module was calling `require "Makefile.PL"` effectively calling `cpanspec/Makefile.pL`
* Add statistics output
* Add a script for batch processing a list of packages

Issue: https://progress.opensuse.org/issues/90047, #21 
