### PR TITLE
Strip pod from summary

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1100,6 +1100,7 @@ for my $ofile (@args) {
     $license = "CHECK($perllicense)" unless $license;
     $stats{license}->{spec} = $license;
 
+    $summary =~ s/[CL]<([^>]+)>/$1/g if defined $summary;
     $summary //= get_summary($summary, $content, $module);
     $description //= $summary;
     $stats{summary} = $summary;


### PR DESCRIPTION
It can happen that the summary in META.(yml|json) still contains POD.

   # https://metacpan.org/release/ETHER/JSON-MaybeXS-1.004004/source/META.json#L2
   "abstract" : "Use L<Cpanel::JSON::XS> with a fallback to L<JSON::XS> and L<JSON::PP>",