### PR TITLE
Switch to faster CPAN mirror

### DIFF
--- a/bin/update-perl
+++ b/bin/update-perl
@@ -26,7 +26,7 @@ usage(), exit 1 if (not $project or not $data);
 
 my $cpan2obs = CPAN2OBS->new({
     data => $data,
-    cpanmirror => 'http://cpan.noris.de',
+    cpanmirror => 'http://cpan.metacpan.org',
     apiurl => 'https://api.opensuse.org',
     cpanspec => "$Bin/../cpanspec",
     project_prefix => $project,


### PR DESCRIPTION
The mirror cpan.metacpan.org updates almost immediately after PAUSE uploads and is hosted by Fastly. So should be a better default choice than cpan.noris.de, which takes at least a few hours.