### PR TITLE
Add blank line after %autosetup

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1346,6 +1346,7 @@ END
     my $autosetup_arg = (!$config->{patches} || $all_patch_args_same) ? (defined($common_patch_args) ? " $common_patch_args" : "") : " -N";
         print $spec <<END;
 \%autosetup @{[($noprefix ? "" : " -n $buildpath")]}$autosetup_arg
+
 END
 
     if ($execs) {


### PR DESCRIPTION
The following find command seemed to confuse SLE12 and resulted in the patch and find command on one line.

Spec:

    %autosetup  -n %{cpan_name}-v%{version} -p1
    find . -type f ! -path "*/t/*" ...

Executed command:

    /usr/bin/patch -p1 -sfind . -type f '!' -path '*/t/*' '!' -name '*.pl' '!' -path '*/bin/*' '!' -path '*/script/*' '!' -name configure -print0

Issue: https://progress.opensuse.org/issues/122110