### PR TITLE
Fix code for Module::Build(::Tiny)

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1038,15 +1038,8 @@ for my $ofile (@args) {
     $debug and warn __PACKAGE__.':'.__LINE__.$".Data::Dumper->Dump([\$dynamic], ['dynamic']);
 
     my $usebuildpl  = 0;
-    my $usebuildplt = 0;
     if (grep /^Build\.PL$/, @files) {
         $usebuildpl = 1;
-        if (defined $build_requires{'Module::Build::Tiny'}) {
-            $usebuildplt = 1;
-        }
-        else {
-            $build_requires{'Module::Build'} ||= 0;
-        }
     }
     else {
         $build_requires{'ExtUtils::MakeMaker'} ||= 0;
@@ -1408,17 +1401,10 @@ END
         print $spec $config->{custom_build} . "\n";
     }
     else {
-        if ($usebuildplt) {
+        if ($usebuildpl) {
             print $spec <<END;
 $makefile_env$cmdperl Build.PL --installdirs=vendor@{[$noarch ? '' : qq{ optimize="$macro{optimize}"} ]}
 ./Build build --flags=\%{?_smp_mflags}
-
-END
-        }
-        elsif ($usebuildpl) {
-            print $spec <<END;
-$makefile_env$cmdperl Build.PL installdirs=vendor@{[$noarch ? '' : qq{ optimize="$macro{optimize}"} ]}
-./Build build flags=\%{?_smp_mflags}
 
 END
         }
@@ -1463,11 +1449,8 @@ END
 \%install
 END
 
-    if ($usebuildplt) {
+    if ($usebuildpl) {
         print $spec "./Build install --destdir=$macro{buildroot} --create_packlist=0\n";
-    }
-    elsif ($usebuildpl) {
-        print $spec "./Build install destdir=$macro{buildroot} create_packlist=0\n";
     }
     else {
         print $spec <<END;


### PR DESCRIPTION
According to the author both modules understand the syntax with dashes, but only Module::Build understands the syntax without dashes.

We are currently seeing failures:
```
[    7s] + cd /home/abuild/rpmbuild/BUILD
[    7s] + /usr/bin/rm -rf /home/abuild/rpmbuild/BUILDROOT/perl-Module-Build-Tiny-0.046-22.1.x86_64
[    7s] + /usr/bin/mkdir -p /home/abuild/rpmbuild/BUILDROOT
[    7s] + /usr/bin/mkdir /home/abuild/rpmbuild/BUILDROOT/perl-Module-Build-Tiny-0.046-22.1.x86_64
[    7s] + cd Module-Build-Tiny-0.046
[    7s] + ./Build install destdir=/home/abuild/rpmbuild/BUILDROOT/perl-Module-Build-Tiny-0.046-22.1.x86_64 create_packlist=0
[    7s] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[    7s] ERROR: Can't create '/usr/lib/perl5/site_perl/5.36.1/Module/Build'
[    7s] mkdir /usr/lib/perl5/site_perl/5.36.1/Module: Permission denied at /usr/lib/perl5/5.36.1/ExtUtils/Install.pm line 470.
[    7s] 
[    7s] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[    7s]  at lib/Module/Build/Tiny.pm line 149.
```
because cpanspec only uses Module::Build::Tiny syntax if it is listed in the requirements.
Not sure why it stopped working now, but this fix should work in any case.