### PR TITLE
Fix copyright year

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -1125,6 +1125,7 @@ for my $ofile (@args) {
     rmtree($basedir);
     my $rpm_version = map_version($module, $version);
     my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time);
+    $year += 1900;
 
     print $spec <<END;
 #


### PR DESCRIPTION
it probably went unnoticed because `obs-service-format_spec_file`
rewrites it, if installed.