### PR TITLE
Always use %autosetup -p1

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -815,6 +815,10 @@ for my $r (split(/ /, $config->{ignore_requires} || '')) {
   $config->{ignored_requires}->{$r} = 1;
 }
 my @args      = @ARGV;
+
+main() unless caller(); # allow unit testing
+
+sub main {
 my @processed = ();
 local $Data::Dumper::Sortkeys = 1;
 
@@ -1206,14 +1210,11 @@ END
     if ($config_file) {
         print $spec "Source$counter:     $config_file\n";
     }
-    if ($config->{patches}) {
-        $counter = 0;
-        for my $p (sort keys %{$config->{patches}}) {
-            my $args = $config->{patches}->{$p} || '';
-            print $spec "# $1\n" if $args =~ / ?(PATCH-FIX.*)/;
-            print $spec "Patch$counter:   $p\n";
-            $counter++;
-        }
+
+    my $patches = process_patches($config);
+
+    for my $source (@{ $patches->{sources} }) {
+        print $spec "$source\n";
     }
 
     if ($config->{skip_noarch}) {
@@ -1322,23 +1323,8 @@ $description
 \%prep
 END
 
-    my $all_patch_args_same = 1;
-    my $common_patch_args = undef;
-    if ($config->{patches}) {
-        for my $p (sort keys %{$config->{patches}}) {
-            my $args = $config->{patches}->{$p} || undef;
-            $args =~ s/ ?PATCH-FIX.*// if defined($args);
-            if (!defined($common_patch_args) && defined($args)) {
-                $common_patch_args = $args;
-            }
-            $all_patch_args_same = ($args // '') eq ($common_patch_args // '');
-            last if !$all_patch_args_same;
-        }
-    }
-
-    my $autosetup_arg = (!$config->{patches} || $all_patch_args_same) ? (defined($common_patch_args) ? " $common_patch_args" : "") : " -N";
-        print $spec <<END;
-\%autosetup @{[($noprefix ? "" : " -n $buildpath")]}$autosetup_arg
+    print $spec <<END;
+\%autosetup @{[($noprefix ? "" : " -n $buildpath")]} $patches->{autosetup_args}
 
 END
 
@@ -1346,19 +1332,8 @@ END
         print $spec qq{find . -type f ! -path "*/t/*" ! -name "*.pl" ! -path "*/bin/*" ! -path "*/script/*" ! -path "*/scripts/*" ! -name "configure" -print0 | xargs -0 chmod 644\n};
     }
 
-    if ($config->{patches} && !$all_patch_args_same) {
-        my $counter = 0;
-        for my $p (sort keys %{$config->{patches}}) {
-
-            my $args = $config->{patches}->{$p} || undef;
-            if (defined($args)) {
-                $args =~ s/ ?PATCH-FIX.*//;
-                print $spec "%patch -P$counter $args\n";
-            } else {
-                print $spec "%patch -P$counter\n";
-            }
-            $counter++;
-        }
+    for my $patch (@{ $patches->{patches} }) {
+        print $spec "$patch\n";
     }
 
     if (@filter_requires) {
@@ -1575,6 +1550,45 @@ END
         die "osc vc failed with $?" if $?;
         close($tfh);
     }
+}
+}
+
+sub process_patches {
+    my ($config) = @_;
+    my @patches;
+    my @patch_sources;
+    my $all_patch_args_same = 1;
+    my %spec = (autosetup_args => '-p1', patches => \@patches, sources => \@patch_sources);
+    return \%spec unless $config->{patches};
+
+    for my $patch (sort keys %{ $config->{patches} }) {
+        my $args = $config->{patches}->{ $patch } // '';
+        $args =~ s/ ?PATCH-FIX.*//;
+        if ($args ne '-p1') {
+            $spec{autosetup_args} = '-N';
+            $all_patch_args_same = 0;
+            last;
+        }
+    }
+
+    my $counter = 0;
+    for my $patch (sort keys %{ $config->{patches} }) {
+        my $args = $config->{patches}->{ $patch } // '';
+        if ($args =~ s/ ?(PATCH-FIX.*)//) {
+            push @patch_sources, "# $1";
+        }
+        push @patch_sources, "Patch$counter:   $patch";
+        next if $all_patch_args_same;
+
+        if (length $args) {
+            push @patches, "%patch -P$counter $args";
+        }
+        else {
+            push @patches, "%patch -P$counter";
+        }
+        $counter++;
+    }
+    return \%spec;
 }
 
 sub prereqs_from_metayaml {

--- a/t/10.basic.t
+++ b/t/10.basic.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin '$Bin';
+
+local @ARGV = 'dummy';
+my $cpanspec = "$Bin/../cpanspec";
+require $cpanspec;
+
+my %config;
+my $spec;
+
+my $label = "no patches";
+$spec = main::process_patches(\%config);
+is $spec->{autosetup_args}, '-p1', "$label (autosetup)";
+is scalar @{ $spec->{sources} }, 0, "$label (sources)";
+is_deeply $spec->{patches}, [], "$label (patches)";
+
+$label = "undef";
+$config{patches} = {
+    'foo.patch' => undef,
+};
+$spec = main::process_patches(\%config);
+is $spec->{autosetup_args}, '-N', "$label (autosetup)";
+like $spec->{sources}->[0], qr{Patch0:.*foo.patch}, "$label (sources)";
+is_deeply $spec->{patches}, ['%patch -P0'], "$label (patches)";
+
+$label = "-p0";
+$config{patches} = {
+    'foo.patch' => '-p0',
+};
+$spec = main::process_patches(\%config);
+is $spec->{autosetup_args}, '-N', "$label (autosetup)";
+like $spec->{sources}->[0], qr{Patch0:.*foo.patch}, "$label (sources)";
+is_deeply $spec->{patches}, ['%patch -P0 -p0'], "$label (patches)";
+
+$label = "-p1";
+$config{patches} = {
+    'foo.patch' => '-p1',
+};
+$spec = main::process_patches(\%config);
+is $spec->{autosetup_args}, '-p1', "$label (autosetup)";
+like $spec->{sources}->[0], qr{Patch0:.*foo.patch}, "$label (sources)";
+is_deeply $spec->{patches}, [], "$label (patches)";
+
+$label = "-p0, -p1 and undef";
+$config{patches} = {
+    'foo.patch' => '-p1',
+    'bar.patch' => '-p0',
+    'boo.patch' => undef,
+};
+$spec = main::process_patches(\%config);
+is $spec->{autosetup_args}, '-N', "$label (autosetup)";
+like $spec->{sources}->[0], qr{Patch0:.*bar.patch}, "$label (source 0)";
+like $spec->{sources}->[1], qr{Patch1:.*boo.patch}, "$label (source 1)";
+like $spec->{sources}->[2], qr{Patch2:.*foo.patch}, "$label (source 2)";
+is_deeply $spec->{patches}, ['%patch -P0 -p0', '%patch -P1', '%patch -P2 -p1'], "$label (patches)";
+
+$label = "-p1 with ref";
+$config{patches} = {
+    'foo.patch' => '-p1 PATCH-FIX-UPSTREAM url',
+};
+$spec = main::process_patches(\%config);
+is $spec->{autosetup_args}, '-p1', "$label (autosetup)";
+like $spec->{sources}->[0], qr{\# PATCH-FIX-UPSTREAM url}, "$label (sources)";
+like $spec->{sources}->[1], qr{Patch0:.*foo.patch}, "$label (sources)";
+is_deeply $spec->{patches}, [], "$label (patches)";
+
+done_testing;
+


### PR DESCRIPTION
For retroactively adding patches it is useful to use the standard `-p1` as an `%autosetup` argument.

If there are patches with different args, they will be added with a `%patch` command.

Issue: https://progress.opensuse.org/issues/175323