### PR TITLE
Remove use of Perl::PrereqScanner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         zypper -n install perl-App-cpanminus make gcc
 
         cpanm -n Archive::Zip Pod::POM Parse::CPAN::Packages
-        Text::Autoformat YAML::XS LWP::UserAgent Perl::PrereqScanner
+        Text::Autoformat YAML::XS LWP::UserAgent
         Algorithm::Diff
     - name: test
       run: perl -c cpanspec
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get install cpanminus
 
         sudo cpanm -n Archive::Zip Pod::POM Parse::CPAN::Packages
-        Text::Autoformat YAML::XS LWP::UserAgent Perl::PrereqScanner
+        Text::Autoformat YAML::XS LWP::UserAgent
         Algorithm::Diff
     - name: test
       run: perl -c cpanspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN zypper refresh \
         perl-Pod-POM \
         perl-libwww-perl \
         perl-Class-Accessor-Chained \
-        perl-Perl-PrereqScanner \
         perl-Algorithm-Diff \
         perl-Module-Build-Tiny \
         perl-ExtUtils-Depends \

--- a/cpanspec
+++ b/cpanspec
@@ -219,7 +219,6 @@ use LWP::UserAgent;
 use Parse::CPAN::Packages;
 use File::Temp;
 use File::Path qw(rmtree);
-use Perl::PrereqScanner;
 use Encode qw/ decode_utf8 /;
 use Encode::Guess;
 use JSON::PP ();
@@ -1659,7 +1658,6 @@ sub prereqs_from_metajson {
 sub parse_provides {
     my ($path, $files) = @_;
     my %provides;
-    my $scanner = Perl::PrereqScanner->new;
     foreach my $test (grep /\.(pm|t|PL|pl)/, @$files) {
         my $doc = PPI::Document->new($path . "/" . $test);
 


### PR DESCRIPTION
It was not used anymore, only the object was still created.

See #58