### PR TITLE
Update README to remove Perl::PrereqScanner

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,6 @@ Requires:
 * perl(Module::Build)
 * perl(Module::Build::Tiny)
 * perl(Parse::CPAN::Packages)
-* perl(Perl::PrereqScanner)
 * perl(Pod::POM)
 * perl(Text::Autoformat)
 * perl(YAML::XS)


### PR DESCRIPTION
See openSUSE/cpanspec#58